### PR TITLE
default to shasum512 if shasum isn't found

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,10 @@ realpath() {
     [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
 }
 
+sha_sum() {
+    [[ $(command -v shasum512) ]] && echo 'shasum512' || echo 'shasum'
+}
+
 PROJECT_ROOT=$(dirname $(realpath -s $0))
 DL_PATH="${DL_PATH:-${PROJECT_ROOT}/tmp/downloads}"
 
@@ -49,7 +53,7 @@ BUILD_OPTS="${BUILD_OPTS:-}"
 SKIP_GPG="${SKIP_GPG:-false}"
 EXCLUDE="${EXCLUDE:-}"
 
-REQUIRED_BINARIES="awk bzip2 grep shasum wget"
+REQUIRED_BINARIES="awk bzip2 grep $(sha_sum) wget"
 [ "${SKIP_GPG}" != "false" ] && REQUIRED_BINARIES+=" gpg"
 
 [ ! -f "${PROJECT_ROOT}/inc/core.sh" ] && echo "error: Could not find ${PROJECT_ROOT}/inc/core.sh" && exit 1

--- a/inc/core.sh
+++ b/inc/core.sh
@@ -19,6 +19,10 @@ msg()
     echo -e "--> $@"
 }
 
+sha_sum() {
+    [[ $(command -v shasum512) ]] && echo 'shasum512' || echo 'shasum -a512'
+}
+
 # Make sure required binaries are in PATH
 has_required_binaries() {
     for BINARY in ${REQUIRED_BINARIES}; do
@@ -97,7 +101,7 @@ download_stage3() {
         gpg --verify "$DL_PATH/${STAGE3_DIGESTS}" || die "insecure digests"
     fi
     SHA512_HASHES=$(grep -A1 SHA512 "$DL_PATH/${STAGE3_DIGESTS}" | grep -v '^--')
-    SHA512_CHECK=$(cd $DL_PATH/ && (echo "${SHA512_HASHES}" | shasum -a512 -c))
+    SHA512_CHECK=$(cd $DL_PATH/ && (echo "${SHA512_HASHES}" | $(sha_sum) -c))
     SHA512_FAILED=$(echo "${SHA512_CHECK}" | grep FAILED)
     if [ -n "${SHA512_FAILED}" ]; then
         die "${SHA512_FAILED}"


### PR DESCRIPTION
On some systems, `shasum` didn't exist but `shasum512` did (CoreOS). Fall back on previous behavior by defaulting to it if it exists.

Fixes https://github.com/edannenberg/gentoo-bb/issues/51.