### PR TITLE
crossdev: add log to stdout on error

### DIFF
--- a/dock/gentoobb/builder/bob-musl/Buildconfig.sh
+++ b/dock/gentoobb/builder/bob-musl/Buildconfig.sh
@@ -15,7 +15,7 @@ priority=9999
 masters = gentoo
 auto-sync = no" > /etc/portage/repos.conf/crossdev.conf
 
-    crossdev -S --init-target --target ${CROSSDEV_MUSL}
+    crossdev --show-fail-log -S --init-target --target ${CROSSDEV_MUSL}
     mkdir -p /usr/${CROSSDEV_MUSL}/etc/portage/package.{mask,unmask,use,keywords} /usr/${CROSSDEV_MUSL}/tmp/
     rm /usr/${CROSSDEV_MUSL}/etc/portage/make.profile
     ln -s /usr/portage/profiles/hardened/linux/musl/amd64 /usr/${CROSSDEV_MUSL}/etc/portage/make.profile
@@ -48,7 +48,7 @@ PKGDIR="/packages/${CHOST}"' /usr/${CROSSDEV_MUSL}/etc/portage/make.conf
     # fix regression in latest toolchain.eclass - see https://bugs.gentoo.org/show_bug.cgi?id=548782
     sed -i 's/\.\/\${dir}\/\*\.la || die/\.\/\${dir}\/\*\.la/g' /usr/portage/eclass/toolchain.eclass
 
-    crossdev -S --target ${CROSSDEV_MUSL}
+    crossdev --show-fail-log -S --target ${CROSSDEV_MUSL}
 
     rm /etc/portage/package.use/gcc
 }

--- a/dock/gentoobb/builder/bob-uclibc/Buildconfig.sh
+++ b/dock/gentoobb/builder/bob-uclibc/Buildconfig.sh
@@ -15,7 +15,7 @@ priority=9999
 masters = gentoo
 auto-sync = no" > /etc/portage/repos.conf/crossdev.conf
 
-    crossdev -S --init-target --target ${CROSSDEV_UCLIBC}
+    crossdev --show-fail-log -S --init-target --target ${CROSSDEV_UCLIBC}
     mkdir -p /usr/${CROSSDEV_UCLIBC}/etc/portage/package.{mask,unmask,use,keywords} /usr/${CROSSDEV_UCLIBC}/tmp/
     rm /usr/${CROSSDEV_UCLIBC}/etc/portage/make.profile
     ln -s /usr/portage/profiles/uclibc/amd64/ /usr/${CROSSDEV_UCLIBC}/etc/portage/make.profile
@@ -46,7 +46,7 @@ PKGDIR="/packages/${CHOST}"' /usr/${CROSSDEV_UCLIBC}/etc/portage/make.conf
     # fix regression in latest toolchain.eclass - see https://bugs.gentoo.org/show_bug.cgi?id=548782
     sed -i 's/\.\/\${dir}\/\*\.la || die/\.\/\${dir}\/\*\.la/g' /usr/portage/eclass/toolchain.eclass
 
-    crossdev -S --target ${CROSSDEV_UCLIBC}
+    crossdev --show-fail-log -S --target ${CROSSDEV_UCLIBC}
 
     rm /etc/portage/package.use/gcc
 }


### PR DESCRIPTION
helpful in case of error to show the ebuild stacktrace without enter the failed container