### PR TITLE
Quote heredoc to turn off interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ END
  $ cat <<END > dock/mynamespace/images/figlet/build.sh
 PACKAGES="app-misc/figlet"
 END
- $ cat <<END > dock/mynamespace/images/figlet/Dockerfile.template
+ $ cat <<'END' > dock/mynamespace/images/figlet/Dockerfile.template
 FROM ${IMAGE_PARENT}
 ADD rootfs.tar /
 CMD ["figlet", "gentoo-bb"]


### PR DESCRIPTION
The example wouldn't escape `${IMAGE_PARENT}` so it would become ``. By quoting the heredoc `'END'` it turns off interpolation, preserving `${IMAGE_PARENT}`. I tested and the mynamespace/figlet image successfully builds after this change.