### PR TITLE
Enable binpkg-multi-instance portage feature

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -37,5 +37,5 @@ BOB_GENTOO_MIRRORS="${BOB_GENTOO_MIRRORS:-ftp://ftp.wh2.tu-dresden.de/pub/mirror
 BOB_SYNC_URI="${BOB_SYNC_URI:-rsync://rsync.europe.gentoo.org/gentoo-portage}"
 BOB_SYNC_TYPE="${BOB_SYNC_TYPE:-rsync}"
 BOB_MAKEOPTS="${BOB_MAKEOPTS:--j9}"
-BOB_FEATURES="${BOB_FEATURES:-parallel-fetch nodoc noinfo noman}"
+BOB_FEATURES="${BOB_FEATURES:-parallel-fetch nodoc noinfo noman binpkg-multi-instance}"
 BOB_EMERGE_DEFAULT_OPTS="${BOB_EMERGE_DEFAULT_OPTS:--b -k}"


### PR DESCRIPTION
This allows for storing even more binary packages for atoms when the they have different USE flags. For example different images might share atoms but have different USE flags, without `binpkg-multi-instance` only one atom will be stored and re-used as a binary the others will always be rebuilt from source, with `binpkg-multi-instance` all will create binary packages for re-use. This speeds up rebuilds.