### PR TITLE
Fix /var/run symlink

### DIFF
--- a/bob-core/build-root.sh
+++ b/bob-core/build-root.sh
@@ -367,7 +367,7 @@ generate_documentation_footer
 unset ROOT
 
 # /run symlink
-mkdir -p $EMERGE_ROOT/var/run && ln -s /run $EMERGE_ROOT/var/run
+mkdir -p $EMERGE_ROOT/run $EMERGE_ROOT/var && ln -s /run $EMERGE_ROOT/var/run
 
 # clean up
 rm -rf $EMERGE_ROOT/var/lib/portage $EMERGE_ROOT/var/cache/edb $EMERGE_ROOT/usr/share/gtk-doc/* $EMERGE_ROOT/var/db/pkg/* $EMERGE_ROOT/etc/ld.so.cache


### PR DESCRIPTION
Previously it would create /var/run/run -> /run, now it creats /var/run -> /run