### PR TITLE
Option to skip baselayout and creating /run and /var, and symlinking /var/run to /run

### DIFF
--- a/bob-core/build-root.sh
+++ b/bob-core/build-root.sh
@@ -367,7 +367,9 @@ generate_documentation_footer
 unset ROOT
 
 # /run symlink
-mkdir -p $EMERGE_ROOT/run $EMERGE_ROOT/var && ln -s /run $EMERGE_ROOT/var/run
+if [ -z "SKIP_VAR_RUN_SYMLINK" ]; then
+    mkdir -p $EMERGE_ROOT/run $EMERGE_ROOT/var && ln -s /run $EMERGE_ROOT/var/run
+fi
 
 # clean up
 rm -rf $EMERGE_ROOT/var/lib/portage $EMERGE_ROOT/var/cache/edb $EMERGE_ROOT/usr/share/gtk-doc/* $EMERGE_ROOT/var/db/pkg/* $EMERGE_ROOT/etc/ld.so.cache

--- a/bob-core/build-root.sh
+++ b/bob-core/build-root.sh
@@ -330,7 +330,9 @@ if [ -n "$PACKAGES" ]; then
     init_docs ${REPO/\images\//}
     generate_doc_package_installed "${PACKAGES}"
 
-    "${EMERGE_BIN}" ${EMERGE_OPT} --binpkg-respect-use=y -v sys-apps/baselayout
+    if [ -z "BOB_SKIP_BASELAYOUT" ]; then
+        "${EMERGE_BIN}" ${EMERGE_OPT} --binpkg-respect-use=y -v sys-apps/baselayout
+    fi
     # install packages (defined via build.sh)
     "${EMERGE_BIN}" ${EMERGE_OPT} --binpkg-respect-use=y -v $PACKAGES
 
@@ -367,8 +369,8 @@ generate_documentation_footer
 unset ROOT
 
 # /run symlink
-if [ -z "SKIP_VAR_RUN_SYMLINK" ]; then
-    mkdir -p $EMERGE_ROOT/run $EMERGE_ROOT/var && ln -s /run $EMERGE_ROOT/var/run
+if [ -z "BOB_SKIP_BASELAYOUT" ]; then
+    mkdir -p $EMERGE_ROOT/{run,var} && ln -s /run $EMERGE_ROOT/var/run
 fi
 
 # clean up


### PR DESCRIPTION
This happens after the last hook, finish_rootfs_build, so unless there's an option that allows it to be skipped, all images will always have `/run/` and `/var/` directories, and a symlink from `/var/run` to `/run`. I want this option to be able to skip this step and avoid creating the directories and symlink.