### PR TITLE
Clean up more files before tar rootfs.tar, based on abuild.in

### DIFF
--- a/bob-core/build-root.sh
+++ b/bob-core/build-root.sh
@@ -390,7 +390,23 @@ if [ -z "BOB_SKIP_BASELAYOUT" ]; then
 fi
 
 # clean up
-rm -rf $EMERGE_ROOT/var/lib/portage $EMERGE_ROOT/var/cache/edb $EMERGE_ROOT/usr/share/gtk-doc/* $EMERGE_ROOT/var/db/pkg/* $EMERGE_ROOT/etc/ld.so.cache
+find "${EMERGE_ROOT}"/lib64 "${EMERGE_ROOT}"/usr/lib64 \
+    -type f \( -name '*.[co]' -o -name '*.prl' \) -delete
+rm -rf \
+    "${EMERGE_ROOT}"/etc/ld.so.cache \
+    "${EMERGE_ROOT}"/usr/bin/*-config \
+    "${EMERGE_ROOT}"/usr/lib64/cmake/ \
+    "${EMERGE_ROOT}"/usr/lib64/pkgconfig/ \
+    "${EMERGE_ROOT}"/usr/lib64/qt*/mkspecs/
+    "${EMERGE_ROOT}"/usr/share/aclocal/ \
+    "${EMERGE_ROOT}"/usr/share/gettext/ \
+    "${EMERGE_ROOT}"/usr/share/gir-[0-9]*/
+    "${EMERGE_ROOT}"/usr/share/gtk-doc/* \
+    "${EMERGE_ROOT}"/usr/share/qt*/mkspecs/ \
+    "${EMERGE_ROOT}"/usr/share/vala/vapi/ \
+    "${EMERGE_ROOT}"/var/cache/edb \
+    "${EMERGE_ROOT}"/var/db/pkg/* \
+    "${EMERGE_ROOT}"/var/lib/portage
 if [ -z "$KEEP_HEADERS" ]; then
     rm -rf $EMERGE_ROOT/usr/include/*
 fi


### PR DESCRIPTION
#85 

Ignored *.a and *.h due I am not sure it will affect other options.