### PR TITLE
Fix BOB_SKIP_BASELAYOUT, should be variable not literal

### DIFF
--- a/bob-core/build-root.sh
+++ b/bob-core/build-root.sh
@@ -346,7 +346,7 @@ if [ -n "$PACKAGES" ]; then
     init_docs ${REPO/\images\//}
     generate_doc_package_installed "${PACKAGES}"
 
-    if [ -z "BOB_SKIP_BASELAYOUT" ]; then
+    if [ -z "$BOB_SKIP_BASELAYOUT" ]; then
         "${EMERGE_BIN}" ${EMERGE_OPT} --binpkg-respect-use=y -v sys-apps/baselayout
     fi
     # install packages (defined via build.sh)
@@ -385,7 +385,7 @@ generate_documentation_footer
 unset ROOT
 
 # /run symlink
-if [ -z "BOB_SKIP_BASELAYOUT" ]; then
+if [ -z "$BOB_SKIP_BASELAYOUT" ]; then
     mkdir -p $EMERGE_ROOT/{run,var} && ln -s /run $EMERGE_ROOT/var/run
 fi
 


### PR DESCRIPTION
In #76 there was a bug where BOB_SKIP_BASELAYOUT is treated as always set. My apologies.

I didn't see any complaints about BOB_SKIP_BASELAYOUT always been treated as set, so that may indicated that for many packages it can be set. But it should be tested per package. It maybe just be not many people updated yet.

This PR fixes the bug. When #58 lands and/or I work out how to do unit tests in bash I'll be sure to use it for this and/or future PRs.