### PR TITLE
doc: rename gentoobb -> kubler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ rootfs.tar
 push.conf
 dock/*/builder/PACKAGES.md
 dock/*
-!dock/gentoobb
 !dock/kubler
 !dock/dummy

--- a/dock/dummy/images/busybox/build.conf
+++ b/dock/dummy/images/busybox/build.conf
@@ -1,4 +1,4 @@
 # valid builder repo id, comment out for namespace default
 #BUILDER="dummy/bob"
-# valid image repo id (i.e. gentoobb/busybox or "scratch")
+# valid image repo id (i.e. kubler/busybox or "scratch")
 IMAGE_PARENT="scratch"


### PR DESCRIPTION
Few missing strays that wasn't fixed through the refactor.